### PR TITLE
Use regex for tag filter

### DIFF
--- a/src/HIDS/QueryBuilder.cs
+++ b/src/HIDS/QueryBuilder.cs
@@ -96,11 +96,10 @@ namespace HIDS
             clauses.Add(RangeClause);
             clauses.Add($"filter(fn: (r) => r._measurement == \"point\")");
 
-            IEnumerable<string> tagConditionals = IncludedTags.Select(tag => $"r.tag == \"{tag}\"");
-            string tagExpression = string.Join(" or ", tagConditionals);
+            string tagExpression = string.Join("|", IncludedTags);
 
             if (tagExpression.Length > 0)
-                clauses.Add($"filter(fn: (r) => {tagExpression})");
+                clauses.Add($"filter(fn: (r) => r.tag =~ /{tagExpression}/)");
 
             IEnumerable<string> timeConditionals = ExcludedTimes
                 .Select(ToConditional)
@@ -167,11 +166,10 @@ namespace HIDS
             clauses.Add($"filter(fn: (r) => r._measurement == \"point\")");
             clauses.Add($"filter(fn: (r) => r._field == \"flags\")");
 
-            IEnumerable<string> tagConditionals = IncludedTags.Select(tag => $"r.tag == \"{tag}\"");
-            string tagExpression = string.Join(" or ", tagConditionals);
+            string tagExpression = string.Join("|", IncludedTags);
 
             if (tagExpression.Length > 0)
-                clauses.Add($"filter(fn: (r) => {tagExpression})");
+                clauses.Add($"filter(fn: (r) => r.tag =~ /{tagExpression}/)");
 
             IEnumerable<string> timeConditionals = ExcludedTimes
                 .Select(ToConditional)


### PR DESCRIPTION
This greatly reduces the raw text size of queries, allowing certain very large queries to be tested using the InfluxDB web interface that would have otherwise crashed due to the size of the query. I also read that this may improve query performance, although it didn't seem to make any difference in my testing.