### PR TITLE
Ping server on connect

### DIFF
--- a/src/HIDS/API.cs
+++ b/src/HIDS/API.cs
@@ -55,7 +55,7 @@ namespace HIDS
             set => m_token = value.ToCharArray();
         }
 
-        public void Connect(string influxDBHost)
+        public async Task ConnectAsync(string influxDBHost)
         {
             InfluxDBClientOptions options = InfluxDBClientOptions.Builder.CreateNew()
                 .Url(influxDBHost)
@@ -63,7 +63,19 @@ namespace HIDS
                 .TimeOut(Timeout.InfiniteTimeSpan)
                 .Build();
 
-            m_client = InfluxDBClientFactory.Create(options);
+            InfluxDBClient client = InfluxDBClientFactory.Create(options);
+
+            try
+            {
+                // Query the version to see
+                // if the server is responding
+                await client.VersionAsync();
+                m_client = client;
+            }
+            catch
+            {
+                client.Dispose();
+            }
         }
 
         public void Disconnect()

--- a/src/HIDS/HIDS.csproj
+++ b/src/HIDS/HIDS.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/GridProtectionAlliance/HIDSAPI</RepositoryUrl>
     <PackageProjectUrl>https://github.com/GridProtectionAlliance/HIDSAPI</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
Detects connectivity errors on connect, before attempting to read or write. This should help prevent issues where queries hang due to firewalls and server outages.