### PR TITLE
Introduce API for cyclic histograms

### DIFF
--- a/src/HIDS/API.Histograms.cs
+++ b/src/HIDS/API.Histograms.cs
@@ -1,0 +1,286 @@
+﻿//******************************************************************************************************
+//  API.Histograms.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  09/26/2023 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using InfluxDB.Client;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Flux.Domain;
+using InfluxDB.Client.Writes;
+
+namespace HIDS
+{
+    public partial class API
+    {
+        public static string DefaultHistogramBucket { get; set; } = "histogram_bucket";
+
+        public string HistogramBucket { get; set; } = DefaultHistogramBucket;
+
+        public async Task WriteHistogramAsync(Histogram histogram)
+        {
+            if (m_client is null)
+                throw new InvalidOperationException("Cannot write histograms: not connected to InfluxDB.");
+
+            TaskCreationOptions runContinuationsAsynchronously = TaskCreationOptions.RunContinuationsAsynchronously;
+            TaskCompletionSource<object?> taskCompletionSource = new TaskCompletionSource<object?>(runContinuationsAsynchronously);
+
+            using WriteApi writeApi = m_client.GetWriteApi();
+
+            writeApi.EventHandler += (sender, args) =>
+            {
+                if (args is WriteErrorEvent errorEvent)
+                    taskCompletionSource.TrySetException(errorEvent.Exception);
+
+                if (args is WriteRuntimeExceptionEvent exceptionEvent)
+                    taskCompletionSource.TrySetException(exceptionEvent.Exception);
+            };
+
+            DateTime startTime = ForceUTC(histogram.Info.StartTime);
+            DateTime endTime = ForceUTC(histogram.Info.EndTime);
+
+            int sampleCount = histogram.Info.SamplingRate / histogram.Info.FundamentalFrequency;
+            string cyclicHistogramData = ToString(histogram.Info.CyclicHistogramBins, sampleCount, histogram.CyclicHistogramData);
+            string residualHistogramData = ToString(histogram.Info.ResidualHistogramBins, sampleCount, histogram.ResidualHistogramData);
+            string frequencyHistogramData = ToString(histogram.Info.FrequencyHistogramBins, 0, histogram.FrequencyHistogramData);
+            string rmsHistogramData = ToString(histogram.Info.RMSHistogramBins, 0, histogram.RMSHistogramData);
+
+            PointData point = PointData
+                .Measurement("histogram")
+                .Tag("tag", histogram.Info.Tag)
+                .Timestamp(startTime, WritePrecision.S)
+                .Field("endTime", endTime.Ticks)
+                .Field("cyclesMax", histogram.Info.CyclesMax)
+                .Field("cyclesMin", histogram.Info.CyclesMin)
+                .Field("residualMax", histogram.Info.ResidualMax)
+                .Field("residualMin", histogram.Info.ResidualMin)
+                .Field("frequencyMax", histogram.Info.FrequencyMax)
+                .Field("frequencyMin", histogram.Info.FrequencyMin)
+                .Field("rmsMax", histogram.Info.RMSMax)
+                .Field("rmsMin", histogram.Info.RMSMin)
+                .Field("cyclicHistogramBins", histogram.Info.CyclicHistogramBins)
+                .Field("residualHistogramBins", histogram.Info.ResidualHistogramBins)
+                .Field("frequencyHistogramBins", histogram.Info.FrequencyHistogramBins)
+                .Field("rmsHistogramBins", histogram.Info.RMSHistogramBins)
+                .Field("cyclicHistogram", cyclicHistogramData)
+                .Field("residualHistogram", residualHistogramData)
+                .Field("frequencyHistogram", frequencyHistogramData)
+                .Field("rmsHistogram", rmsHistogramData);
+
+            writeApi.WritePoint(HistogramBucket, OrganizationID, point);
+
+            writeApi.Dispose();
+            taskCompletionSource.TrySetResult(null);
+            await taskCompletionSource.Task;
+        }
+
+        public IAsyncEnumerable<Histogram.Metadata> ReadHistogramMetadataAsync(IEnumerable<string> tags, DateTime startTime, CancellationToken cancellationToken = default) =>
+            ReadHistogramMetadataAsync(tags, FormatTimestamp(startTime), cancellationToken: cancellationToken);
+
+        public IAsyncEnumerable<Histogram.Metadata> ReadHistogramMetadataAsync(IEnumerable<string> tags, DateTime startTime, DateTime stopTime, CancellationToken cancellationToken = default) =>
+            ReadHistogramMetadataAsync(tags, FormatTimestamp(startTime), FormatTimestamp(stopTime), cancellationToken: cancellationToken);
+
+        public IAsyncEnumerable<Histogram.Metadata> ReadHistogramMetadataAsync(IEnumerable<string> tags, string start, string stop = "-0s", CancellationToken cancellationToken = default)
+        {
+            List<string> clauses = new List<string>(6) { };
+
+            clauses.Add($"from(bucket: \"{HistogramBucket}\")");
+            clauses.Add($"range(start: {start}, stop: {stop})");
+            clauses.Add($"filter(fn: (r) => r._measurement == \"histogram\")");
+            clauses.Add($"filter(fn: (r) => r._field !~ /^(cyclic|residual|frequency|rms)Histogram$/)");
+
+            string tagExpression = string.Join("|", tags);
+
+            if (tagExpression.Length > 0)
+                clauses.Add($"filter(fn: (r) => r.tag =~ /{tagExpression}/)");
+
+            clauses.Add("pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")");
+
+            string fluxQuery = string
+                .Join("\n  |> ", clauses)
+                .Trim();
+
+            return ReadHistogramMetadataAsync(fluxQuery, cancellationToken);
+        }
+
+        public Task<List<Histogram.Point>> ReadCyclicHistogramAsync(string tag, DateTime timestamp, CancellationToken cancellationToken = default) =>
+            ReadHistogramAsync(tag, timestamp, "cyclicHistogram", cancellationToken);
+
+        public Task<List<Histogram.Point>> ReadResidualHistogramAsync(string tag, DateTime timestamp, CancellationToken cancellationToken = default) =>
+            ReadHistogramAsync(tag, timestamp, "residualHistogram", cancellationToken);
+
+        public Task<List<Histogram.Point>> ReadFrequencyHistogramAsync(string tag, DateTime timestamp, CancellationToken cancellationToken = default) =>
+            ReadHistogramAsync(tag, timestamp, "frequencyHistogram", cancellationToken);
+
+        public Task<List<Histogram.Point>> ReadRMSHistogramAsync(string tag, DateTime timestamp, CancellationToken cancellationToken = default) =>
+            ReadHistogramAsync(tag, timestamp, "rmsHistogram", cancellationToken);
+
+        public IAsyncEnumerable<Histogram.Metadata> ReadHistogramMetadataAsync(string fluxQuery, CancellationToken cancellationToken = default)
+        {
+            IAsyncEnumerable<FluxRecord> fluxRecords = ReadFluxRecordsAsync(fluxQuery, cancellationToken);
+
+            return fluxRecords.Select(record => new Histogram.Metadata()
+            {
+                Tag = record.GetValueByKey("tag")?.ToString(),
+                FundamentalFrequency = Convert.ToInt32(record.GetValueByKey("fundamentalFrequency") ?? 0),
+                SamplingRate = Convert.ToInt32(record.GetValueByKey("samplingRate") ?? 0),
+                StartTime = StripTimeZone(record.GetTimeInDateTime().GetValueOrDefault()),
+                EndTime = new DateTime(Convert.ToInt64(record.GetValueByKey("endTime") ?? 0L)),
+                TotalCapturedCycles = Convert.ToInt32(record.GetValueByKey("totalCapturedCycles") ?? 0),
+                CyclesMax = Convert.ToDouble(record.GetValueByKey("cyclesMax") ?? double.NaN),
+                CyclesMin = Convert.ToDouble(record.GetValueByKey("cyclesMin") ?? double.NaN),
+                ResidualMax = Convert.ToDouble(record.GetValueByKey("residualMax") ?? double.NaN),
+                ResidualMin = Convert.ToDouble(record.GetValueByKey("residualMin") ?? double.NaN),
+                FrequencyMax = Convert.ToDouble(record.GetValueByKey("frequencyMax") ?? double.NaN),
+                FrequencyMin = Convert.ToDouble(record.GetValueByKey("frequencyMin") ?? double.NaN),
+                RMSMax = Convert.ToDouble(record.GetValueByKey("rmsMax") ?? double.NaN),
+                RMSMin = Convert.ToDouble(record.GetValueByKey("rmsMin") ?? double.NaN),
+                CyclicHistogramBins = Convert.ToInt32(record.GetValueByKey("cyclicHistogramBins") ?? 0),
+                ResidualHistogramBins = Convert.ToInt32(record.GetValueByKey("residualHistogramBins") ?? 0),
+                FrequencyHistogramBins = Convert.ToInt32(record.GetValueByKey("frequencyHistogramBins") ?? 0),
+                RMSHistogramBins = Convert.ToInt32(record.GetValueByKey("rmsHistogramBins") ?? 0)
+            });
+        }
+
+        public async Task<List<Histogram.Point>> ReadHistogramAsync(string fluxQuery, CancellationToken cancellationToken = default)
+        {
+            IAsyncEnumerable<FluxRecord> fluxRecords = ReadFluxRecordsAsync(fluxQuery, cancellationToken);
+
+            List<Histogram.Point> points = await fluxRecords
+                .Select(record => record.GetValue())
+                .Select(obj => obj?.ToString())
+                .Where(histogramData => !string.IsNullOrEmpty(histogramData))
+                .Select(FromString!)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return points ?? new List<Histogram.Point>(0);
+        }
+
+        private async Task<List<Histogram.Point>> ReadHistogramAsync(string tag, DateTime timestamp, string field, CancellationToken cancellationToken = default)
+        {
+            string formattedTimestamp = FormatTimestamp(timestamp);
+
+            List<string> clauses = new List<string>(5)
+            {
+                $"from(bucket: \"{HistogramBucket}\")",
+                $"range(start: {formattedTimestamp}, stop: date.add(d: 1ns, to: {formattedTimestamp}))",
+                $"filter(fn: (r) => r._measurement == \"histogram\")",
+                $"filter(fn: (r) => r.tag == \"{tag}\")",
+                $"filter(fn: (r) => r._field == \"{field}\")"
+            };
+
+            string importSection = "import \"date\"";
+
+            string querySection = string
+                .Join("\n  |> ", clauses)
+                .Trim();
+
+            string fluxQuery = $"{importSection}\n{querySection}";
+            return await ReadHistogramAsync(fluxQuery, cancellationToken);
+        }
+
+        private static List<Histogram.Point> FromString(string pointData)
+        {
+            byte[] bytes = Convert.FromBase64String(pointData);
+            using MemoryStream memoryStream = new MemoryStream(bytes);
+            using BinaryReader reader = new BinaryReader(memoryStream);
+
+            Func<int> GetReadFunction(byte byteSize)
+            {
+                if (byteSize == 0)
+                    return () => 0;
+                if (byteSize == sizeof(byte))
+                    return () => reader.ReadByte();
+                if (byteSize == sizeof(ushort))
+                    return () => reader.ReadUInt16();
+                return () => reader.ReadInt32();
+            }
+
+            byte binByteSize = reader.ReadByte();
+            byte sampleByteSize = reader.ReadByte();
+            Func<int> binReadFunction = GetReadFunction(binByteSize);
+            Func<int> sampleReadFunction = GetReadFunction(sampleByteSize);
+            List<Histogram.Point> points = new List<Histogram.Point>();
+
+            while (memoryStream.Length - memoryStream.Position > binByteSize + sampleByteSize + sizeof(float))
+            {
+                Histogram.Point point = new Histogram.Point();
+                point.Bin = binReadFunction.Invoke();
+                point.Sample = sampleReadFunction.Invoke();
+                point.Value = reader.ReadSingle();
+                points.Add(point);
+            }
+
+            return points;
+        }
+
+        private static string ToString(int bins, int samples, List<Histogram.Point> points)
+        {
+            using MemoryStream memoryStream = new MemoryStream();
+            using BinaryWriter writer = new BinaryWriter(memoryStream);
+
+            byte GetByteSize(int maxValue)
+            {
+                if (maxValue == 0)
+                    return 0;
+                if (maxValue < byte.MaxValue)
+                    return sizeof(byte);
+                if (maxValue < ushort.MaxValue)
+                    return sizeof(ushort);
+                return sizeof(int);
+            }
+
+            Action<int> GetWriteAction(int maxValue)
+            {
+                if (maxValue == 0)
+                    return num => { };
+                if (maxValue < byte.MaxValue)
+                    return num => writer.Write((byte)num);
+                if (maxValue < ushort.MaxValue)
+                    return num => writer.Write((ushort)num);
+                return num => writer.Write(num);
+            }
+
+            writer.Write(GetByteSize(bins));
+            writer.Write(GetByteSize(samples));
+
+            Action<int> binWriter = GetWriteAction(bins);
+            Action<int> sampleWriter = GetWriteAction(samples);
+
+            foreach (Histogram.Point point in points)
+            {
+                binWriter.Invoke(point.Bin);
+                sampleWriter.Invoke(point.Sample);
+                writer.Write(point.Value);
+            }
+
+            writer.Flush();
+
+            byte[] bytes = memoryStream.ToArray();
+            return Convert.ToBase64String(bytes);
+        }
+    }
+}

--- a/src/HIDS/API.Points.cs
+++ b/src/HIDS/API.Points.cs
@@ -1,0 +1,135 @@
+﻿//******************************************************************************************************
+//  API.Points.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  09/26/2023 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using InfluxDB.Client;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Flux.Domain;
+using InfluxDB.Client.Writes;
+
+namespace HIDS
+{
+    public partial class API
+    {
+        public static string DefaultPointBucket { get; set; } = "point_bucket";
+
+        public string PointBucket { get; set; } = DefaultPointBucket;
+
+        public async Task WritePointsAsync(IEnumerable<Point> points)
+        {
+            if (m_client is null)
+                throw new InvalidOperationException("Cannot write points: not connected to InfluxDB.");
+
+            TaskCreationOptions runContinuationsAsynchronously = TaskCreationOptions.RunContinuationsAsynchronously;
+            TaskCompletionSource<object?> taskCompletionSource = new TaskCompletionSource<object?>(runContinuationsAsynchronously);
+
+            using WriteApi writeApi = m_client.GetWriteApi();
+
+            writeApi.EventHandler += (sender, args) =>
+            {
+                if (args is WriteErrorEvent errorEvent)
+                    taskCompletionSource.TrySetException(errorEvent.Exception);
+
+                if (args is WriteRuntimeExceptionEvent exceptionEvent)
+                    taskCompletionSource.TrySetException(exceptionEvent.Exception);
+            };
+
+            foreach (Point point in points)
+            {
+                if (taskCompletionSource.Task.IsFaulted)
+                    break;
+
+                writeApi.WriteMeasurement(PointBucket, OrganizationID, WritePrecision.Ns, point);
+            }
+
+            writeApi.Dispose();
+            taskCompletionSource.TrySetResult(null);
+            await taskCompletionSource.Task;
+        }
+
+        public IAsyncEnumerable<Point> ReadPointsAsync(IEnumerable<string> tags, DateTime startTime, DateTime stopTime, CancellationToken cancellationToken = default) =>
+            ReadPointsAsync(tags, FormatTimestamp(startTime), FormatTimestamp(stopTime), cancellationToken);
+
+        public IAsyncEnumerable<Point> ReadPointsAsync(IEnumerable<string> tags, DateTime startTime, CancellationToken cancellationToken = default) =>
+            ReadPointsAsync(tags, FormatTimestamp(startTime), cancellationToken: cancellationToken);
+
+        public IAsyncEnumerable<Point> ReadPointsAsync(IEnumerable<string> tags, string start, string stop = "-0s", CancellationToken cancellationToken = default)
+        {
+            void ConfigureQuery(IQueryBuilder queryBuilder) => queryBuilder
+                .Range(start, stop)
+                .FilterTags(tags)
+                .TestQuality(~0u);
+
+            return ReadPointsAsync(ConfigureQuery, cancellationToken);
+        }
+
+        public IAsyncEnumerable<Point> ReadPointsAsync(Action<IQueryBuilder> configureQuery, CancellationToken cancellationToken = default)
+        {
+            QueryBuilder queryBuilder = new QueryBuilder(PointBucket);
+            configureQuery(queryBuilder);
+
+            string query = queryBuilder.BuildPointQuery();
+            return ReadPointsAsync(query, cancellationToken);
+        }
+
+        public IAsyncEnumerable<PointCount> ReadPointCountAsync(Action<IQueryBuilder> configureQuery, CancellationToken cancellationToken = default)
+        {
+            QueryBuilder queryBuilder = new QueryBuilder(PointBucket);
+            configureQuery(queryBuilder);
+
+            string query = queryBuilder.BuildCountQuery();
+            return ReadPointCountAsync(query, cancellationToken);
+        }
+
+        public IAsyncEnumerable<Point> ReadPointsAsync(string fluxQuery, CancellationToken cancellationToken = default)
+        {
+            IAsyncEnumerable<FluxRecord> fluxRecords = ReadFluxRecordsAsync(fluxQuery, cancellationToken);
+
+            return fluxRecords.Select(record => new Point()
+            {
+                Tag = record.GetValueByKey("tag")?.ToString(),
+                Timestamp = StripTimeZone(record.GetTimeInDateTime().GetValueOrDefault()),
+                QualityFlags = Convert.ToUInt32(record.GetValueByKey("flags") ?? 0),
+                Minimum = Convert.ToDouble(record.GetValueByKey("min") ?? double.NaN),
+                Maximum = Convert.ToDouble(record.GetValueByKey("max") ?? double.NaN),
+                Average = Convert.ToDouble(record.GetValueByKey("avg") ?? double.NaN)
+            });
+        }
+
+        public IAsyncEnumerable<PointCount> ReadPointCountAsync(string fluxQuery, CancellationToken cancellationToken = default)
+        {
+            IAsyncEnumerable<FluxRecord> fluxRecords = ReadFluxRecordsAsync(fluxQuery, cancellationToken);
+
+            return fluxRecords.Select(record => new PointCount()
+            {
+                Tag = record.GetValueByKey("tag")?.ToString(),
+                Timestamp = StripTimeZone(record.GetTimeInDateTime().GetValueOrDefault()),
+                Count = Convert.ToUInt64(record.GetValue())
+            });
+        }
+    }
+}

--- a/src/HIDS/API.cs
+++ b/src/HIDS/API.cs
@@ -23,29 +23,23 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client;
-using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Core.Flux.Domain;
-using InfluxDB.Client.Writes;
 using Newtonsoft.Json;
 
 namespace HIDS
 {
-    public class API : IDisposable
+    public partial class API : IDisposable
     {
-        public static string DefaultPointBucket = "point_bucket";
-        public static string DefaultOrganizationID = "gpa";
+        public static string DefaultOrganizationID { get; set; } = "gpa";
 
         private InfluxDBClient? m_client;
         private char[] m_token = Array.Empty<char>();
         private bool m_disposed;
-
-        public string PointBucket { get; set; } = DefaultPointBucket;
 
         public string OrganizationID { get; set; } = DefaultOrganizationID;
 
@@ -106,99 +100,6 @@ namespace HIDS
             {
                 m_disposed = true;
             }
-        }
-
-        public async Task WritePointsAsync(IEnumerable<Point> points)
-        {
-            if (m_client is null)
-                throw new InvalidOperationException("Cannot write points: not connected to InfluxDB.");
-
-            TaskCreationOptions runContinuationsAsynchronously = TaskCreationOptions.RunContinuationsAsynchronously;
-            TaskCompletionSource<object?> taskCompletionSource = new TaskCompletionSource<object?>(runContinuationsAsynchronously);
-
-            using WriteApi writeApi = m_client.GetWriteApi();
-
-            writeApi.EventHandler += (sender, args) =>
-            {
-                if (args is WriteErrorEvent errorEvent)
-                    taskCompletionSource.TrySetException(errorEvent.Exception);
-
-                if (args is WriteRuntimeExceptionEvent exceptionEvent)
-                    taskCompletionSource.TrySetException(exceptionEvent.Exception);
-            };
-
-            foreach (Point point in points)
-            {
-                if (taskCompletionSource.Task.IsFaulted)
-                    break;
-
-                writeApi.WriteMeasurement(PointBucket, OrganizationID, WritePrecision.Ns, point);
-            }
-
-            writeApi.Dispose();
-            taskCompletionSource.TrySetResult(null);
-            await taskCompletionSource.Task;
-        }
-
-        public IAsyncEnumerable<Point> ReadPointsAsync(IEnumerable<string> tags, DateTime startTime, DateTime stopTime, CancellationToken cancellationToken = default) =>
-            ReadPointsAsync(tags, FormatTimestamp(startTime), FormatTimestamp(stopTime), cancellationToken);
-
-        public IAsyncEnumerable<Point> ReadPointsAsync(IEnumerable<string> tags, DateTime startTime, CancellationToken cancellationToken = default) =>
-            ReadPointsAsync(tags, FormatTimestamp(startTime), cancellationToken: cancellationToken);
-
-        public IAsyncEnumerable<Point> ReadPointsAsync(IEnumerable<string> tags, string start, string stop = "-0s", CancellationToken cancellationToken = default)
-        {
-            void ConfigureQuery(IQueryBuilder queryBuilder) => queryBuilder
-                .Range(start, stop)
-                .FilterTags(tags)
-                .TestQuality(~0u);
-
-            return ReadPointsAsync(ConfigureQuery, cancellationToken);
-        }
-
-        public IAsyncEnumerable<Point> ReadPointsAsync(Action<IQueryBuilder> configureQuery, CancellationToken cancellationToken = default)
-        {
-            QueryBuilder queryBuilder = new QueryBuilder(PointBucket);
-            configureQuery(queryBuilder);
-
-            string query = queryBuilder.BuildPointQuery();
-            return ReadPointsAsync(query, cancellationToken);
-        }
-
-        public IAsyncEnumerable<PointCount> ReadPointCountAsync(Action<IQueryBuilder> configureQuery, CancellationToken cancellationToken = default)
-        {
-            QueryBuilder queryBuilder = new QueryBuilder(PointBucket);
-            configureQuery(queryBuilder);
-
-            string query = queryBuilder.BuildCountQuery();
-            return ReadPointCountAsync(query, cancellationToken);
-        }
-
-        public IAsyncEnumerable<Point> ReadPointsAsync(string fluxQuery, CancellationToken cancellationToken = default)
-        {
-            IAsyncEnumerable<FluxRecord> fluxRecords = ReadFluxRecordsAsync(fluxQuery, cancellationToken);
-
-            return fluxRecords.Select(record => new Point()
-            {
-                Tag = record.GetValueByKey("tag")?.ToString(),
-                Timestamp = StripTimeZone(record.GetTimeInDateTime().GetValueOrDefault()),
-                QualityFlags = Convert.ToUInt32(record.GetValueByKey("flags") ?? 0),
-                Minimum = Convert.ToDouble(record.GetValueByKey("min") ?? double.NaN),
-                Maximum = Convert.ToDouble(record.GetValueByKey("max") ?? double.NaN),
-                Average = Convert.ToDouble(record.GetValueByKey("avg") ?? double.NaN)
-            });
-        }
-
-        public IAsyncEnumerable<PointCount> ReadPointCountAsync(string fluxQuery, CancellationToken cancellationToken = default)
-        {
-            IAsyncEnumerable<FluxRecord> fluxRecords = ReadFluxRecordsAsync(fluxQuery, cancellationToken);
-
-            return fluxRecords.Select(record => new PointCount()
-            {
-                Tag = record.GetValueByKey("tag")?.ToString(),
-                Timestamp = StripTimeZone(record.GetTimeInDateTime().GetValueOrDefault()),
-                Count = Convert.ToUInt64(record.GetValue())
-            });
         }
 
         private async IAsyncEnumerable<FluxRecord> ReadFluxRecordsAsync(string fluxQuery, [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/src/HIDS/HIDS.csproj
+++ b/src/HIDS/HIDS.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/GridProtectionAlliance/HIDSAPI</RepositoryUrl>
     <PackageProjectUrl>https://github.com/GridProtectionAlliance/HIDSAPI</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.5</Version>
+    <Version>1.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/HIDS/Histogram.cs
+++ b/src/HIDS/Histogram.cs
@@ -1,0 +1,66 @@
+﻿//******************************************************************************************************
+//  CyclicHistogram.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  09/22/2023 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace HIDS
+{
+    public class Histogram
+    {
+        public class Metadata
+        {
+            public string? Tag { get; set; }
+            public int FundamentalFrequency { get; set; }
+            public int SamplingRate { get; set; }
+            public DateTime StartTime { get; set; }
+            public DateTime EndTime { get; set; }
+            public int TotalCapturedCycles { get; set; }
+            public double CyclesMax { get; set; }
+            public double CyclesMin { get; set; }
+            public double ResidualMax { get; set; }
+            public double ResidualMin { get; set; }
+            public double FrequencyMax { get; set; }
+            public double FrequencyMin { get; set; }
+            public double RMSMax { get; set; }
+            public double RMSMin { get; set; }
+            public int CyclicHistogramBins { get; set; }
+            public int ResidualHistogramBins { get; set; }
+            public int FrequencyHistogramBins { get; set; }
+            public int RMSHistogramBins { get; set; }
+        }
+
+        public class Point
+        {
+            public int Bin { get; set; }
+            public int Sample { get; set; }
+            public float Value { get; set; }
+        }
+
+        public Metadata Info { get; } = new Metadata();
+        public List<Point> CyclicHistogramData { get; set; } = new List<Point>();
+        public List<Point> ResidualHistogramData { get; set; } = new List<Point>();
+        public List<Point> FrequencyHistogramData { get; set; } = new List<Point>();
+        public List<Point> RMSHistogramData { get; set; } = new List<Point>();
+    }
+}

--- a/src/HIDS/QueryBuilder.cs
+++ b/src/HIDS/QueryBuilder.cs
@@ -90,7 +90,7 @@ namespace HIDS
         public string BuildPointQuery()
         {
             List<string> imports = new List<string>(4);
-            List<string> clauses = new List<string>(16);
+            List<string> clauses = new List<string>(16) { };
 
             clauses.Add(FromClause);
             clauses.Add(RangeClause);
@@ -159,7 +159,7 @@ namespace HIDS
         public string BuildCountQuery()
         {
             List<string> imports = new List<string>(4);
-            List<string> clauses = new List<string>(16);
+            List<string> clauses = new List<string>(16) { };
 
             clauses.Add(FromClause);
             clauses.Add(RangeClause);


### PR DESCRIPTION
In addition to simply adding the additional API functions...

* Reorganized code in the `API` class by making it a partial class.
* In `QueryBuilder.cs`: Although we certainly _could_ use a list initializer to replace some of the calls to `clauses.Add()`, others need to be separate from the initializer because they are either conditionally added or added after a conditionally added clause. I was ignoring the compiler's suggestion because I believe it's easier to read the code if the syntax for adding clauses is applied in a uniform manner throughout the function. Turns out we can clear the compiler suggestion by adding an empty list initializer, as strange as that may be.