### PR TITLE
Write missing histogram fields to InfluxDB

### DIFF
--- a/src/HIDS/API.Histograms.cs
+++ b/src/HIDS/API.Histograms.cs
@@ -71,6 +71,8 @@ namespace HIDS
             PointData point = PointData
                 .Measurement("histogram")
                 .Tag("tag", histogram.Info.Tag)
+                .Field("fundamentalFrequency", histogram.Info.FundamentalFrequency)
+                .Field("samplingRate", histogram.Info.SamplingRate)
                 .Timestamp(startTime, WritePrecision.S)
                 .Field("endTime", endTime.Ticks)
                 .Field("cyclesMax", histogram.Info.CyclesMax)

--- a/src/HIDS/HIDS.csproj
+++ b/src/HIDS/HIDS.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/GridProtectionAlliance/HIDSAPI</RepositoryUrl>
     <PackageProjectUrl>https://github.com/GridProtectionAlliance/HIDSAPI</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
The `fundamentalFrequency` and `samplingRate` fields were being used to generate the histogram data to be written to the database, but they were not themselves being written to the metadata record. The code was already trying to read these values back out of the database so this should be all that's needed to close the loop.